### PR TITLE
Add onFrame callback

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -56,3 +56,6 @@ android/app/libs
 fastlane/report.xml
 fastlane/Preview.html
 fastlane/screenshots
+
+# Visual Studio Code
+.vscode

--- a/android/src/main/java/fr/greweb/rnwebgl/RNWebGLView.java
+++ b/android/src/main/java/fr/greweb/rnwebgl/RNWebGLView.java
@@ -65,11 +65,15 @@ public class RNWebGLView extends GLSurfaceView implements GLSurfaceView.Renderer
     }
     mEventQueue.clear();
 
+    // Call frame event after each frame is drawn
+    WritableMap event = Arguments.createMap();
+    reactContext.getJSModule(RCTEventEmitter.class).receiveEvent(getId(), "frame", event);
+
     // ctxId may be unset if we get here (on the GL thread) before RNWebGLContextCreate(...) is
     // called on the JS thread to create the RNWebGL context and save its id (see above in
     // the implementation of `onSurfaceCreated(...)`)
     if (ctxId > 0) {
-      RNWebGLContextFlush(ctxId);
+        RNWebGLContextFlush(ctxId);
     }
   }
 

--- a/android/src/main/java/fr/greweb/rnwebgl/RNWebGLViewManager.java
+++ b/android/src/main/java/fr/greweb/rnwebgl/RNWebGLViewManager.java
@@ -25,6 +25,8 @@ public class RNWebGLViewManager extends SimpleViewManager<RNWebGLView> {
   public @Nullable Map getExportedCustomDirectEventTypeConstants() {
     return MapBuilder.of(
             "surfaceCreate",
-            MapBuilder.of("registrationName", "onSurfaceCreate"));
+            MapBuilder.of("registrationName", "onSurfaceCreate"),
+            "frame",
+            MapBuilder.of("registrationName", "onFrame"));
   }
 }

--- a/example/ios/example.xcodeproj/project.pbxproj
+++ b/example/ios/example.xcodeproj/project.pbxproj
@@ -103,6 +103,20 @@
 			remoteGlobalIDString = 83CBBA2E1A601D0E00E9B192;
 			remoteInfo = React;
 		};
+		149FF1741FA75B0B0075DD13 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 139FDEE61B06529A00C62182 /* RCTWebSocket.xcodeproj */;
+			proxyType = 2;
+			remoteGlobalIDString = 3DBE0D001F3B181A0099AA32;
+			remoteInfo = fishhook;
+		};
+		149FF1761FA75B0B0075DD13 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 139FDEE61B06529A00C62182 /* RCTWebSocket.xcodeproj */;
+			proxyType = 2;
+			remoteGlobalIDString = 3DBE0D0D1F3B181C0099AA32;
+			remoteInfo = "fishhook-tvOS";
+		};
 		2D02E4911E0B4A5D006451C7 /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
 			containerPortal = 83CBB9F71A601CBA00E9B192 /* Project object */;
@@ -420,6 +434,8 @@
 			children = (
 				139FDEF41B06529B00C62182 /* libRCTWebSocket.a */,
 				3DAD3E991DF850E9000B6D8A /* libRCTWebSocket-tvOS.a */,
+				149FF1751FA75B0B0075DD13 /* libfishhook.a */,
+				149FF1771FA75B0B0075DD13 /* libfishhook-tvOS.a */,
 			);
 			name = Products;
 			sourceTree = "<group>";
@@ -620,7 +636,11 @@
 				TargetAttributes = {
 					00E356ED1AD99517003FC87E = {
 						CreatedOnToolsVersion = 6.2;
+						DevelopmentTeam = V485XZT2WB;
 						TestTargetID = 13B07F861A680F5B00A75B9A;
+					};
+					13B07F861A680F5B00A75B9A = {
+						DevelopmentTeam = V485XZT2WB;
 					};
 					2D02E47A1E0B4A5D006451C7 = {
 						CreatedOnToolsVersion = 8.2.1;
@@ -759,6 +779,20 @@
 			fileType = archive.ar;
 			path = libReact.a;
 			remoteRef = 146834031AC3E56700842450 /* PBXContainerItemProxy */;
+			sourceTree = BUILT_PRODUCTS_DIR;
+		};
+		149FF1751FA75B0B0075DD13 /* libfishhook.a */ = {
+			isa = PBXReferenceProxy;
+			fileType = archive.ar;
+			path = libfishhook.a;
+			remoteRef = 149FF1741FA75B0B0075DD13 /* PBXContainerItemProxy */;
+			sourceTree = BUILT_PRODUCTS_DIR;
+		};
+		149FF1771FA75B0B0075DD13 /* libfishhook-tvOS.a */ = {
+			isa = PBXReferenceProxy;
+			fileType = archive.ar;
+			path = "libfishhook-tvOS.a";
+			remoteRef = 149FF1761FA75B0B0075DD13 /* PBXContainerItemProxy */;
 			sourceTree = BUILT_PRODUCTS_DIR;
 		};
 		341611631F48BB72004A5873 /* libthird-party.a */ = {
@@ -1049,6 +1083,7 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				BUNDLE_LOADER = "$(TEST_HOST)";
+				DEVELOPMENT_TEAM = V485XZT2WB;
 				GCC_PREPROCESSOR_DEFINITIONS = (
 					"DEBUG=1",
 					"$(inherited)",
@@ -1070,6 +1105,7 @@
 			buildSettings = {
 				BUNDLE_LOADER = "$(TEST_HOST)";
 				COPY_PHASE_STRIP = NO;
+				DEVELOPMENT_TEAM = V485XZT2WB;
 				INFOPLIST_FILE = exampleTests/Info.plist;
 				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
@@ -1088,6 +1124,7 @@
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CURRENT_PROJECT_VERSION = 1;
 				DEAD_CODE_STRIPPING = NO;
+				DEVELOPMENT_TEAM = V485XZT2WB;
 				INFOPLIST_FILE = example/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
 				OTHER_LDFLAGS = (
@@ -1105,6 +1142,7 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CURRENT_PROJECT_VERSION = 1;
+				DEVELOPMENT_TEAM = V485XZT2WB;
 				INFOPLIST_FILE = example/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
 				OTHER_LDFLAGS = (

--- a/ios/RNWebGLView.h
+++ b/ios/RNWebGLView.h
@@ -7,5 +7,6 @@
 - (instancetype)initWithManager:(RNWebGLViewManager *)mgr;
 
 @property (nonatomic, copy) RCTDirectEventBlock onSurfaceCreate;
+@property (nonatomic, copy) RCTBubblingEventBlock onFrame;
 
 @end

--- a/ios/RNWebGLView.m
+++ b/ios/RNWebGLView.m
@@ -236,6 +236,9 @@ RCT_NOT_IMPLEMENTED(- (instancetype)init);
     [EAGLContext setCurrentContext:_eaglCtx];
     RNWebGLContextSetDefaultFramebuffer(_ctxId, _msaaFramebuffer);
     RNWebGLContextFlush(_ctxId);
+      
+    // onFrame callback
+    self.onFrame(@{});
 
     // Present current state of view buffers
     // TODO(nikki): This should happen exactly at `endFrame()` in the queue

--- a/ios/RNWebGLViewManager.m
+++ b/ios/RNWebGLViewManager.m
@@ -11,6 +11,7 @@ RCT_EXPORT_MODULE(RNWebGLViewManager);
 }
 
 RCT_EXPORT_VIEW_PROPERTY(onSurfaceCreate, RCTDirectEventBlock);
+RCT_EXPORT_VIEW_PROPERTY(onFrame, RCTBubblingEventBlock);
 RCT_EXPORT_VIEW_PROPERTY(msaaSamples, NSNumber);
 
 @end

--- a/src/WebGLView.js
+++ b/src/WebGLView.js
@@ -37,15 +37,18 @@ const getGl = (ctxId: number): ?WebGLRenderingContext => {
   return gl;
 };
 
-export default class WebGLView extends React.Component {
-  props: {
-    onContextCreate: (gl: WebGLRenderingContext) => void,
-    onContextFailure: (e: Error) => void,
-    msaaSamples: number
-  };
+type Props = {
+  onContextCreate: (gl: WebGLRenderingContext) => void,
+  onContextFailure: (e: Error) => void,
+  onFrame: () => void,
+  msaaSamples: number
+};
+
+export default class WebGLView extends React.Component<Props> {
   static propTypes = {
     onContextCreate: PropTypes.func,
     onContextFailure: PropTypes.func,
+    onFrame: PropTypes.func,
     msaaSamples: PropTypes.number,
     ...ViewPropTypes
   };
@@ -58,6 +61,7 @@ export default class WebGLView extends React.Component {
     const {
       onContextCreate, // eslint-disable-line no-unused-vars
       onContextFailure, // eslint-disable-line no-unused-vars
+      onFrame, // eslint-disable-line no-unused-vars
       msaaSamples,
       ...viewProps
     } = this.props;
@@ -69,6 +73,7 @@ export default class WebGLView extends React.Component {
         <WebGLView.NativeView
           style={{ flex: 1, backgroundColor: "transparent" }}
           onSurfaceCreate={this.onSurfaceCreate}
+          onFrame={this.onFrame}
           msaaSamples={Platform.OS === "ios" ? msaaSamples : undefined}
         />
       </View>
@@ -98,6 +103,13 @@ export default class WebGLView extends React.Component {
     } else if (gl && this.props.onContextCreate) {
       this.props.onContextCreate(gl);
     }
+  };
+
+  onFrame = (): void => {
+    if (!this.props.onFrame) {
+      return;
+    }
+    this.props.onFrame();
   };
 
   static NativeView = requireNativeComponent("RNWebGLView", WebGLView, {


### PR DESCRIPTION
This pull request adds an `onFrame` callback as described in https://github.com/expo/expo/issues/538 and https://github.com/react-community/react-native-webgl/issues/14. The implementation may have some problems but it works on both Android and iOS.
I updated the Three.js example to use the `onFrame` callback.
Also add start/stop rotation on touch to Three.js example.