### PR TITLE
Fix for RN 0.50.1

### DIFF
--- a/android/src/main/java/fr/greweb/rnwebgl/RNWebGLView.java
+++ b/android/src/main/java/fr/greweb/rnwebgl/RNWebGLView.java
@@ -47,7 +47,7 @@ public class RNWebGLView extends GLSurfaceView implements GLSurfaceView.Renderer
       reactContext.runOnJSQueueThread(new Runnable() {
         @Override
         public void run() {
-          ctxId = RNWebGLContextCreate(reactContext.getJavaScriptContext());
+          ctxId = RNWebGLContextCreate(reactContext.getJavaScriptContextHolder().get());
           mGLViewMap.put(ctxId, glView);
           WritableMap arg = Arguments.createMap();
           arg.putInt("ctxId", ctxId);


### PR DESCRIPTION
**Probably a Breaking Change**

Updating the file accordingly to fix this error I got during `react-native run-android`:

```
RNWebGLView.java:50: error: cannot find symbol
          ctxId = RNWebGLContextCreate(reactContext.getJavaScriptContext());
                                                   ^
  symbol:   method getJavaScriptContext()
  location: variable reactContext of type ReactContext
```

Digging into the codebase (don't really know when) that method got modified to [this](https://github.com/facebook/react-native/blob/master/ReactAndroid/src/main/java/com/facebook/react/bridge/ReactContext.java#L377).

By fixing the code I'm able to use the lib accordingly on Android.