### PR TITLE
defined window.addEventListener

### DIFF
--- a/example/src/three.js
+++ b/example/src/three.js
@@ -1,4 +1,6 @@
 const THREE = require("three");
 global.THREE = THREE;
+if (!window.addEventListener)
+    window.addEventListener = () => { };
 require("three/examples/js/renderers/Projector");
 export default THREE;


### PR DESCRIPTION
In the latest version of three.js, when creating the WebGLRenderer, an error occurs because the window does not have 'addEventListener' method
 https://github.com/mrdoob/three.js/blob/dev/src/renderers/webvr/WebVRManager.js#L66