### PR TITLE
Update build.gradle

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -97,8 +97,8 @@ task prepareJSC(dependsOn: downloadJSCHeaders) << {
 }
 
 task buildRNWebGLLib(dependsOn: [prepareJSC], type: Exec) {
-  inputs.file('src/main/jni')
-  inputs.file('../cpp')
+  inputs.dir('src/main/jni')
+  inputs.dir('../cpp')
   outputs.dir("$buildDir/exgl/all")
   commandLine getNdkBuildFullPath(),
           'NDK_PROJECT_PATH=null',


### PR DESCRIPTION
This PR fixes:

```
[1] Some problems were found with the configuration of task ':react-native-webgl:buildRNWebGLLib'. Registering invalid inputs and outputs via TaskInputs and TaskOutputs methods has been deprecated and is scheduled to be removed in Gradle 5.0.
[1]  - File '.../node_modules/react-native-webgl/android/src/main/jni' specified for property '$1' is not a file.
[1]  - File '.../node_modules/react-native-webgl/cpp' specified for property '$2' is not a file.
```