### PR TITLE
Fixed Android build on >= RN56

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -124,12 +124,12 @@ task packageRNWebGLLibs(dependsOn: buildRNWebGLLib, type: Copy) {
 }
 
 android {
-  compileSdkVersion 24
-  buildToolsVersion '25.0.0'
+  compileSdkVersion project.hasProperty('compileSdkVersion') ? project.compileSdkVersion : 24
+  buildToolsVersion project.hasProperty('buildToolsVersion') ? project.buildToolsVersion : '25.0.0'
 
   defaultConfig {
     minSdkVersion 17
-    targetSdkVersion 24
+    targetSdkVersion project.hasProperty('targetSdkVersion') ? project.targetSdkVersion : 24
     versionCode 1
     versionName "1.0"
     ndk {


### PR DESCRIPTION
Hi, this fixes `react-native-webgl` for react-native >= 0.56.
It ensures that the correct compile, build and target SDK version is used from the react-native project itsself, and reduces dependencies of this library itself.