### PR TITLE
[Android] use libc++ instead of gnustl

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -118,8 +118,8 @@ task cleanRNWebGLLib(type: Exec) {
 
 task packageRNWebGLLibs(dependsOn: buildRNWebGLLib, type: Copy) {
   from "$buildDir/exgl/all"
-  exclude '**/libjsc.so'
-  exclude '**/libgnustl_shared.so'
+  exclude "**/libjsc.so"
+  exclude "**/libc++_shared.so"
   into "$buildDir/exgl/exported"
 }
 

--- a/android/src/main/jni/Application.mk
+++ b/android/src/main/jni/Application.mk
@@ -1,13 +1,13 @@
 APP_BUILD_SCRIPT := Android.mk
 
 APP_ABI := armeabi-v7a x86
-APP_PLATFORM := android-9
+APP_PLATFORM := android-16
 
 APP_MK_DIR := $(dir $(lastword $(MAKEFILE_LIST)))
 
 NDK_MODULE_PATH:=.$(HOST_DIRSEP)$(THIRD_PARTY_NDK_DIR)
 
-APP_STL := gnustl_shared
+APP_STL := c++_shared
 APP_CPPFLAGS := -std=c++11 -fexceptions -pthread
 
 # Make sure every shared lib includes a .note.gnu.build-id header
@@ -16,5 +16,3 @@ APP_LDFLAGS += -llog
 APP_LDFLAGS += -lGLESv2
 APP_LDFLAGS += -pthread
 APP_LDFLAGS += -ljnigraphics
-
-NDK_TOOLCHAIN_VERSION := 4.9


### PR DESCRIPTION
Solves #76

gnustl was removed in Android NDK 18 and without this fix we have to stick to v17.
