### PR TITLE
Update to CLANG and LLVM's libc++ Library

### DIFF
--- a/android/src/main/jni/Application.mk
+++ b/android/src/main/jni/Application.mk
@@ -1,13 +1,13 @@
 APP_BUILD_SCRIPT := Android.mk
 
 APP_ABI := armeabi-v7a x86
-APP_PLATFORM := android-9
+APP_PLATFORM := android-16
 
 APP_MK_DIR := $(dir $(lastword $(MAKEFILE_LIST)))
 
 NDK_MODULE_PATH:=.$(HOST_DIRSEP)$(THIRD_PARTY_NDK_DIR)
 
-APP_STL := gnustl_shared
+APP_STL := c++_static
 APP_CPPFLAGS := -std=c++11 -fexceptions -pthread
 
 # Make sure every shared lib includes a .note.gnu.build-id header
@@ -17,4 +17,4 @@ APP_LDFLAGS += -lGLESv2
 APP_LDFLAGS += -pthread
 APP_LDFLAGS += -ljnigraphics
 
-NDK_TOOLCHAIN_VERSION := 4.9
+


### PR DESCRIPTION
According to Androids CLANG migration "https://android.googlesource.com/platform/ndk/+/master/docs/ClangMigration.md#how-to-fix-common-problems" upgrading to GCC is by removing "NDK_TOOLCHAIN"
Also gnustl has been depreciated: "https://developer.android.com/ndk/guides/cpp-support" But 'c++_static' works.' c++_shared' does not (this was just trial and error, correct me if I am wrong). LLVM's libc++ is the C++ standard library that has been used by the Android OS since Lollipop, and as of NDK r18 is the only STL available in the NDK