### PR TITLE
Add GL_UNPACK_ALIGNMENT and GL_PACK_ALIGNMENT params to the WebGL pixelStorei method

### DIFF
--- a/cpp/RNWebGL.cpp
+++ b/cpp/RNWebGL.cpp
@@ -651,6 +651,18 @@ private:
       case GL_UNPACK_FLIP_Y_WEBGL:
         unpackFLipY = param;
         break;
+      case GL_UNPACK_ALIGNMENT:
+        glPixelStorei(GL_UNPACK_ALIGNMENT, param);
+        break;
+      case GL_PACK_ALIGNMENT:
+        glPixelStorei(GL_PACK_ALIGNMENT, param);
+        break;
+      case GL_UNPACK_PREMULTIPLY_ALPHA_WEBGL:
+        RNWebGLSysLog("RNWebGL: gl.pixelStorei() UNPACK_PREMULTIPLY_ALPHA_WEBGL is not supported yet");
+        break;
+      case GL_UNPACK_COLORSPACE_CONVERSION_WEBGL:
+        RNWebGLSysLog("RNWebGL: gl.pixelStorei() UNPACK_COLORSPACE_CONVERSION_WEBGL is not supported yet");
+        break;
       default:
         RNWebGLSysLog("RNWebGL: gl.pixelStorei() doesn't support this parameter yet!");
         break;


### PR DESCRIPTION
# Summary
OpenGL ES 2.0 supports the `GL_PACK_ALIGNMENT` and `GL_UNPACK_ALIGNMENT` out-of-the-box. This PR simply passes the parameters to the `glPixelStorei` method.

## Test Plan

### What's required for testing (prerequisites)?
None.

### What are the steps to reproduce (after prerequisites)?
None.

## Compatibility

| OS      | Implemented |
| ------- | :---------: |
| iOS     |    ✅     |
| Android |    ✅     |

## Checklist

<!-- Check completed item, when applicable, via: [X] -->

- [X] I have tested this on a device and a simulator
- [ ] I added the documentation in `README.md`
- [ ] I mentioned this change in `CHANGELOG.md`
- [ ] I updated the typed files (TS and Flow)
- [ ] I added a sample use of the API in the example project (`example/App.js`)
